### PR TITLE
Rename AppCards to Cards and add new stories

### DIFF
--- a/cx-portal-shared-components/src/components/content/Cards/AppCards.stories.tsx
+++ b/cx-portal-shared-components/src/components/content/Cards/AppCards.stories.tsx
@@ -1,0 +1,39 @@
+import { ComponentStory } from '@storybook/react'
+
+import { Cards as Component } from '.'
+
+export default {
+  title: 'Cards',
+  component: Component,
+  argTypes: {},
+}
+
+const Template: ComponentStory<typeof Component> = (args: any) => (
+  <>
+    <Component {...args} />
+  </>
+)
+
+const item = {
+  title: 'Digital Twin Aspect Debugger',
+  subtitle: 'Catena-X',
+  image: {
+    src: 'https://images.unsplash.com/photo-1517153295259-74eb0b416cee?auto=format&fit=crop&w=640&q=420',
+    alt: 'Catena-X Card',
+  },
+  rating: 4.5,
+  price: 'free to use',
+  description: 'Lorem Ipsum is simply dummy text of the printing.',
+  onButtonClick: () => {},
+  onSecondaryButtonClick: () => {},
+}
+
+export const AppCards = Template.bind({})
+AppCards.args = {
+  items: [item, item],
+  variant: 'minimal',
+  expandOnHover: false,
+  buttonText: 'Details',
+  columns: 6,
+  filledBackground: false,
+}

--- a/cx-portal-shared-components/src/components/content/Cards/Card.tsx
+++ b/cx-portal-shared-components/src/components/content/Cards/Card.tsx
@@ -1,15 +1,15 @@
 import { Box, Link, useTheme } from '@mui/material'
 import { useEffect, useRef, useState } from 'react'
-import { AppCardButtons, AppCardButtonsProps } from './AppCardButtons'
-import { AppCardContent, AppCardContentProps } from './AppCardContent'
-import { AppCardImage, AppCardImageProps } from './AppCardImage'
+import { CardButtons, CardButtonsProps } from './CardButtons'
+import { CardContent, CardContentProps } from './CardContent'
+import { CardImage, CardImageProps } from './CardImage'
 
 type Variants = 'minimal' | 'compact' | 'expanded' | 'preview' | 'text-only'
 
-export interface AppCardProps
-  extends AppCardContentProps,
-    AppCardButtonsProps,
-    AppCardImageProps {
+export interface CardProps
+  extends CardContentProps,
+    CardButtonsProps,
+    CardImageProps {
   variant?: Exclude<Variants, 'preview'>
   filledBackground?: boolean
   expandOnHover?: boolean
@@ -17,7 +17,7 @@ export interface AppCardProps
   readMoreLink?: string
 }
 
-export const AppCard = ({
+export const Card = ({
   variant: variantProp = 'minimal',
   expandOnHover = false,
   filledBackground,
@@ -34,13 +34,13 @@ export const AppCard = ({
   onSecondaryButtonClick,
   readMoreText,
   readMoreLink,
-}: AppCardProps) => {
+}: CardProps) => {
   const { shape, shadows, spacing } = useTheme()
   const [variant, setVariant] = useState(variantProp as Variants)
   const [content, setContent] = useState({
     title,
     subtitle,
-  } as AppCardContentProps)
+  } as CardContentProps)
   const boxRef = useRef<HTMLDivElement>(null)
   const [showButton, setShowButton] = useState(false)
   const [boxHeight, setBoxHeight] = useState<number | undefined>()
@@ -116,9 +116,9 @@ export const AppCard = ({
             },
           }),
         }}
-        className="app-card"
+        className="card"
       >
-        <AppCardImage
+        <CardImage
           image={image}
           imageSize={imageSize}
           imageShape={imageShape}
@@ -132,9 +132,9 @@ export const AppCard = ({
             }),
           }}
         >
-          <AppCardContent {...content} />
+          <CardContent {...content} />
           {showButton && (
-            <AppCardButtons
+            <CardButtons
               buttonText={buttonText}
               onButtonClick={onButtonClick}
               onSecondaryButtonClick={onSecondaryButtonClick}

--- a/cx-portal-shared-components/src/components/content/Cards/CardButtons.tsx
+++ b/cx-portal-shared-components/src/components/content/Cards/CardButtons.tsx
@@ -3,17 +3,17 @@ import { Button } from '../../basic/Button'
 import { IconButton } from '../../basic/IconButton'
 import AddIcon from '@mui/icons-material/Add'
 
-export interface AppCardButtonsProps {
+export interface CardButtonsProps {
   buttonText: string
   onButtonClick?: React.MouseEventHandler
   onSecondaryButtonClick?: React.MouseEventHandler
 }
 
-export const AppCardButtons = ({
+export const CardButtons = ({
   buttonText,
   onButtonClick = () => {},
   onSecondaryButtonClick,
-}: AppCardButtonsProps) => {
+}: CardButtonsProps) => {
   return (
     <Box
       sx={{

--- a/cx-portal-shared-components/src/components/content/Cards/CardContent.tsx
+++ b/cx-portal-shared-components/src/components/content/Cards/CardContent.tsx
@@ -1,21 +1,21 @@
 import { Box } from '@mui/material'
 import { Typography } from '../../basic/Typography'
-import { AppCardRating, AppCardRatingProps } from './AppCardRating'
+import { CardRating, CardRatingProps } from './CardRating'
 
-export interface AppCardContentProps extends Partial<AppCardRatingProps> {
+export interface CardContentProps extends Partial<CardRatingProps> {
   title: string
   subtitle?: string
   price?: string
   description?: string
 }
 
-export const AppCardContent = ({
+export const CardContent = ({
   title,
   subtitle,
   rating,
   price,
   description,
-}: AppCardContentProps) => {
+}: CardContentProps) => {
   return (
     <Box>
       {subtitle && (
@@ -35,7 +35,7 @@ export const AppCardContent = ({
             marginTop: 1,
           }}
         >
-          <AppCardRating rating={rating} />
+          <CardRating rating={rating} />
           <Typography variant="caption3">{price}</Typography>
         </Box>
       )}

--- a/cx-portal-shared-components/src/components/content/Cards/CardImage.tsx
+++ b/cx-portal-shared-components/src/components/content/Cards/CardImage.tsx
@@ -1,27 +1,27 @@
 import { Box, useTheme } from '@mui/material'
 
-export type AppCardImageSize = 'normal' | 'medium' | 'small'
+export type CardImageSize = 'normal' | 'medium' | 'small'
 
-export type AppCardImageShape = 'round' | 'square'
+export type CardImageShape = 'round' | 'square'
 
-export interface IAppCardImage {
+export interface ICardImage {
   src: string
   alt?: string
 }
 
-export interface AppCardImageProps {
-  image: IAppCardImage
-  imageSize?: AppCardImageSize
-  imageShape?: AppCardImageShape
+export interface CardImageProps {
+  image: ICardImage
+  imageSize?: CardImageSize
+  imageShape?: CardImageShape
   preview?: boolean
 }
 
-export const AppCardImage = ({
+export const CardImage = ({
   image,
   imageSize = 'normal',
   imageShape = 'round',
   preview = false,
-}: AppCardImageProps) => {
+}: CardImageProps) => {
   const { transitions } = useTheme()
   const withPreview = (size: number) => (preview ? size + 18 : size)
 

--- a/cx-portal-shared-components/src/components/content/Cards/CardRating.tsx
+++ b/cx-portal-shared-components/src/components/content/Cards/CardRating.tsx
@@ -2,11 +2,11 @@ import { Box, useTheme } from '@mui/material'
 import { Typography } from '../../basic/Typography'
 import StarRateIcon from '@mui/icons-material/StarRate'
 
-export interface AppCardRatingProps {
+export interface CardRatingProps {
   rating: number
 }
 
-export const AppCardRating = ({ rating }: AppCardRatingProps) => {
+export const CardRating = ({ rating }: CardRatingProps) => {
   const { palette } = useTheme()
 
   return (

--- a/cx-portal-shared-components/src/components/content/Cards/ContentCards.stories.tsx
+++ b/cx-portal-shared-components/src/components/content/Cards/ContentCards.stories.tsx
@@ -1,9 +1,9 @@
 import { ComponentStory } from '@storybook/react'
 
-import { AppCards as Component } from '.'
+import { Cards as Component } from '.'
 
 export default {
-  title: 'AppCards',
+  title: 'Cards',
   component: Component,
   argTypes: {},
 }
@@ -15,27 +15,24 @@ const Template: ComponentStory<typeof Component> = (args: any) => (
 )
 
 const item = {
-  title: 'Digital Twin Aspect Debugger',
+  title: 'Catena-X News',
   subtitle: 'Catena-X',
   image: {
     src: 'https://images.unsplash.com/photo-1517153295259-74eb0b416cee?auto=format&fit=crop&w=640&q=420',
-    alt: 'Catena-X AppCard',
+    alt: 'Catena-X Card',
   },
-  rating: 4.5,
-  price: 'free to use',
   description: 'Lorem Ipsum is simply dummy text of the printing.',
   onButtonClick: () => {},
-  onSecondaryButtonClick: () => {},
   readMoreText: 'Read more',
   readMoreLink: '#',
 }
 
-export const AppCards = Template.bind({})
-AppCards.args = {
-  items: [item, item],
-  variant: 'minimal',
-  expandOnHover: false,
-  buttonText: 'Details',
+export const ContentCards = Template.bind({})
+ContentCards.args = {
   columns: 6,
-  filledBackground: true,
+  items: [item, item],
+  variant: 'text-only',
+  buttonText: 'Details',
+  imageSize: 'medium',
+  imageShape: 'round',
 }

--- a/cx-portal-shared-components/src/components/content/Cards/index.tsx
+++ b/cx-portal-shared-components/src/components/content/Cards/index.tsx
@@ -1,26 +1,26 @@
 import { Box, useTheme } from '@mui/material'
-import { AppCard, AppCardProps } from './AppCard'
+import { Card, CardProps } from './Card'
 import uniqueId from 'lodash/uniqueId'
 
-export type AppCardItems = Omit<
-  AppCardProps,
+export type CardItems = Omit<
+  CardProps,
   'variant' | 'imageSize' | 'imageShape' | 'buttonText'
 >
 
-interface AppCardsProps {
-  items: AppCardItems[]
-  buttonText: AppCardProps['buttonText']
-  variant?: AppCardProps['variant']
-  expandOnHover?: AppCardProps['expandOnHover']
-  filledBackground?: AppCardProps['filledBackground']
-  imageSize?: AppCardProps['imageSize']
-  imageShape?: AppCardProps['imageShape']
+interface CardsProps {
+  items: CardItems[]
+  buttonText: CardProps['buttonText']
+  variant?: CardProps['variant']
+  expandOnHover?: CardProps['expandOnHover']
+  filledBackground?: CardProps['filledBackground']
+  imageSize?: CardProps['imageSize']
+  imageShape?: CardProps['imageShape']
   columns?: number
-  readMoreText?: AppCardProps['readMoreText']
-  readMoreLink?: AppCardProps['readMoreLink']
+  readMoreText?: CardProps['readMoreText']
+  readMoreLink?: CardProps['readMoreLink']
 }
 
-export const AppCards = ({
+export const Cards = ({
   items,
   buttonText,
   readMoreText,
@@ -31,7 +31,7 @@ export const AppCards = ({
   columns = 6,
   expandOnHover,
   filledBackground,
-}: AppCardsProps) => {
+}: CardsProps) => {
   const settings = {
     variant,
     buttonText,
@@ -53,7 +53,7 @@ export const AppCards = ({
       }}
     >
       {items?.map((item) => (
-        <AppCard {...settings} {...item} key={uniqueId('AppCards')} />
+        <Card {...settings} {...item} key={uniqueId('Cards')} />
       ))}
     </Box>
   )

--- a/cx-portal-shared-components/src/components/index.tsx
+++ b/cx-portal-shared-components/src/components/index.tsx
@@ -24,11 +24,11 @@ export { Layout as DropzoneLayout } from './basic/Dropzone/components/Layout'
 export { InputContent as DropzoneInputContent } from './basic/Dropzone/components/InputContent'
 export { Chip } from './basic/Chip'
 
-export { AppCards } from './content/AppCards'
+export { Cards } from './content/Cards'
 export { Navigation } from './content/Navigation'
 export { UserMenu } from './content/UserMenu'
 export { UserNav } from './content/UserNav'
 
 export type { TableProps } from './basic/Table'
-export type { AppCardItems } from './content/AppCards'
+export type { CardItems } from './content/Cards'
 export type { NavigationProps } from './content/Navigation'

--- a/cx-portal/src/components/pages/Appstore/index.tsx
+++ b/cx-portal/src/components/pages/Appstore/index.tsx
@@ -2,11 +2,7 @@ import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Outlet, useSearchParams } from 'react-router-dom'
 import { api } from 'state/api'
-import {
-  AppCardItems,
-  AppCards,
-  SearchInput,
-} from 'cx-portal-shared-components'
+import { CardItems, Cards, SearchInput } from 'cx-portal-shared-components'
 import { RootState } from 'state/store'
 
 const Appstore = () => {
@@ -30,14 +26,14 @@ const Appstore = () => {
         }
       />
       <nav>
-        <AppCards
+        <Cards
           items={apps
             .filter(
-              (app: AppCardItems) =>
+              (app: CardItems) =>
                 filter.test(app.title) || filter.test(app.subtitle || '')
             )
-            .map((app: AppCardItems) => {
-              const item: AppCardItems = { ...app }
+            .map((app: CardItems) => {
+              const item: CardItems = { ...app }
               item.image = {
                 src: 'https://images.unsplash.com/photo-1517153295259-74eb0b416cee?auto=format&fit=crop&w=640&q=420',
                 alt: 'Catena-X AppCard',

--- a/cx-portal/src/components/pages/Dashboard/components/AppStoreSection/index.tsx
+++ b/cx-portal/src/components/pages/Dashboard/components/AppStoreSection/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { AppCards, Button, Typography } from 'cx-portal-shared-components'
+import { Cards, Button, Typography } from 'cx-portal-shared-components'
 import './app-store-section.scss'
 
 export default function AppStoreSection() {
@@ -28,7 +28,7 @@ export default function AppStoreSection() {
       >
         {t('content.dashboard.appStoreSection.title')}
       </Typography>
-      <AppCards
+      <Cards
         items={[item, item, item, item, item, item, item, item]} // TODO: Replace from api
         columns={4}
         buttonText="Details"

--- a/cx-portal/src/components/pages/Dashboard/components/NewsSection/index.tsx
+++ b/cx-portal/src/components/pages/Dashboard/components/NewsSection/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { AppCards, Button } from 'cx-portal-shared-components'
+import { Cards, Button } from 'cx-portal-shared-components'
 import './news-section.scss'
 
 export default function NewsSection() {
@@ -20,14 +20,13 @@ export default function NewsSection() {
 
   return (
     <section className="news-section">
-      <AppCards
+      <Cards
         items={[item, item, item]} // TODO: Replace from api
         columns={3}
         buttonText="Details"
         imageSize="medium"
         imageShape="round"
         variant="text-only"
-        expandOnHover={false}
       />
       <Button
         sx={{ margin: '200px auto 0', display: 'block' }}

--- a/cx-portal/src/components/pages/UserManagement/AppArea/index.tsx
+++ b/cx-portal/src/components/pages/UserManagement/AppArea/index.tsx
@@ -1,4 +1,4 @@
-import { AppCards, Typography } from 'cx-portal-shared-components'
+import { Cards, Typography } from 'cx-portal-shared-components'
 import { useTranslation } from 'react-i18next'
 
 export const AppArea = () => {
@@ -21,7 +21,7 @@ export const AppArea = () => {
       <Typography variant="h3" className="section-title">
         {t('content.usermanagement.apparea.headline')}
       </Typography>
-      <AppCards
+      <Cards
         items={[item, item, item, item]} // TODO: Replace from api
         columns={4}
         buttonText="Details"


### PR DESCRIPTION
As in a "CoP: CX Front End Developer"-Meeting discussed:
- Renamed "AppCards" to "Cards";
- Added stories for AppCards and ContentCards as example.