### PR TITLE
licenses via redux and simplified build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ log/
 **/storybook-static
 **/_storybook
 **/src/ignore
-**/third-party-licenses.txt
+**/third-party-licenses.*
 
 # misc
 **/.DS_Store

--- a/cx-portal-shared-components/package.json
+++ b/cx-portal-shared-components/package.json
@@ -16,9 +16,9 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:ci": "CI=true react-scripts test",
-    "clean": "rm -rf ./build ./dist ./storybook-static",
-    "storybook": "start-storybook -p 6006 -s public",
-    "build:storybook": "mkdir -p ./public && build-storybook -s public && rm -rf ../cx-portal/public/_storybook && mv ./storybook-static ../cx-portal/public/_storybook"
+    "clean": "rimraf ./build ./dist ./storybook-static",
+    "start:storybook": "start-storybook -p 6006 -s public",
+    "build:storybook": "mkdirp public && build-storybook -s public && rimraf ../cx-portal/public/_storybook && mv-cli ./storybook-static ../cx-portal/public/_storybook"
   },
   "dependencies": {
     "@mui/x-data-grid": "^5.6.0",

--- a/cx-portal/package.json
+++ b/cx-portal/package.json
@@ -10,10 +10,10 @@
     "test:watch": "react-scripts test --watch",
     "test:ci": "CI=true react-scripts test",
     "eject": "react-scripts eject",
-    "clean": "rm -rf ./build ./dist ./storybook-static ./public/_storybook ./public/third-party-licenses.txt",
+    "clean": "rimraf ./build ./dist ./storybook-static ./public/_storybook ./public/third-party-licenses.txt",
     "start:storybook": "start-storybook -p 6006 -s public",
     "build:storybook": "build-storybook -s public",
-    "build:dist": "yarn run build && mkdir -p dist && cd build && 7z u ../dist/build.zip .",
+    "build:dist": "yarn run build && mkdirp dist && cd build && 7z u ../dist/build.zip .",
     "deploy": "export CX_ENV=${CX_ENV:-dev003} && az webapp deployment source config-zip --resource-group catenax-${CX_ENV}-rg --name catenax-${CX_ENV}-app-portal-2 --src ./dist/build.zip"
   },
   "dependencies": {

--- a/cx-portal/src/components/pages/ThirdPartyLicenses/index.tsx
+++ b/cx-portal/src/components/pages/ThirdPartyLicenses/index.tsx
@@ -13,7 +13,6 @@ export default function ThirdPartyLicenses() {
   const { token } = useSelector(selectorUser)
   const [filterExpr, setFilterExpr] = useState<string>('')
   const [filter, setFilter] = useState<RegExp>(/./)
-  //const { data } = useApiGet('third-party-licenses.json')
   const { items } = useSelector(licensesSelector)
 
   useEffect(() => {
@@ -52,7 +51,7 @@ export default function ThirdPartyLicenses() {
         {items?.data.body
           .filter(
             (pkg: string[]) =>
-              filter.test(pkg[0]) || filter.test(pkg[2]) || filter.test(pkg[4])
+              filter.test(pkg[0]) || filter.test(pkg[2]) || filter.test(pkg[5])
           )
           .map((pkg: string[], i: number) => (
             <li key={i}>

--- a/cx-portal/src/components/pages/ThirdPartyLicenses/index.tsx
+++ b/cx-portal/src/components/pages/ThirdPartyLicenses/index.tsx
@@ -1,14 +1,26 @@
 import { SearchInput } from 'cx-portal-shared-components'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
+import { fetchItems } from 'state/features/licenses/actions'
+import { licensesSelector } from 'state/features/licenses/slice'
+import { selectorUser } from 'state/features/user/userSlice'
 import debounce from 'lodash.debounce'
-import { useApiGet } from 'utils/useApiGet'
 
 export default function ThirdPartyLicenses() {
   const { t } = useTranslation('footer', { keyPrefix: 'licenses' })
+  const dispatch = useDispatch()
+  const { token } = useSelector(selectorUser)
   const [filterExpr, setFilterExpr] = useState<string>('')
   const [filter, setFilter] = useState<RegExp>(/./)
-  const { data } = useApiGet('third-party-licenses.txt')
+  //const { data } = useApiGet('third-party-licenses.json')
+  const { items } = useSelector(licensesSelector)
+
+  useEffect(() => {
+    if (token) {
+      dispatch(fetchItems())
+    }
+  }, [token, dispatch])
 
   const debouncedFilter = useMemo(
     () =>
@@ -37,20 +49,16 @@ export default function ThirdPartyLicenses() {
         onChange={(event) => doFilter(event.target.value)}
       />
       <ul>
-        {data
-          .split('\n')
-          .filter((pkg: string) => filter.test(pkg))
-          .map((pkg, i) => (
+        {items?.data.body
+          .filter(
+            (pkg: string[]) =>
+              filter.test(pkg[0]) || filter.test(pkg[2]) || filter.test(pkg[4])
+          )
+          .map((pkg: string[], i: number) => (
             <li key={i}>
-              {pkg.split(',').map((value, i) =>
-                i === 0 ? (
-                  <a key={i} href={`https://www.npmjs.com/package/${value}`}>
-                    {value}
-                  </a>
-                ) : (
-                  <span key={i}> {value} </span>
-                )
-              )}
+              <a href={`https://www.npmjs.com/package/${pkg[0]}`}>{pkg[0]}</a>
+              <span> {pkg[1]} </span>
+              <span> {pkg[2]} </span>
             </li>
           ))}
       </ul>

--- a/cx-portal/src/state/api/index.ts
+++ b/cx-portal/src/state/api/index.ts
@@ -2,14 +2,12 @@ import { loadApps } from 'state/features/apps/apps'
 import { PartnerNetworkApi } from 'state/api/partnerNetwork/partnerNetworkApi'
 import { UserAdministrationApi } from './userAdministration/userAdministrationAPI'
 import { AppMarketplaceApi } from './appMarketplace/appMarketplace'
-import { NewsApi } from 'state/features/news/api'
 
 const api = {
   loadApps: loadApps,
   PartnerNetworkApi,
   UserAdministrationApi,
   AppMarketplaceApi,
-  NewsApi,
 }
 
 export { api }

--- a/cx-portal/src/state/features/licenses/actions.ts
+++ b/cx-portal/src/state/features/licenses/actions.ts
@@ -1,9 +1,9 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { NewsApi } from './api'
+import { LicensesApi } from './api'
 
-const fetchItems = createAsyncThunk('news/fetchItems', async () => {
+const fetchItems = createAsyncThunk('licenses/fetchItems', async () => {
   try {
-    return await NewsApi.getInstance().getItems()
+    return await LicensesApi.getInstance().getItems()
   } catch (error: unknown) {
     console.error('api call error:', error)
     throw Error('fetchItems api call error')

--- a/cx-portal/src/state/features/licenses/api.ts
+++ b/cx-portal/src/state/features/licenses/api.ts
@@ -1,0 +1,26 @@
+import UserService from 'services/UserService'
+import { HttpClient } from 'utils/HttpClient'
+import { LicenseType } from './types'
+
+export class LicensesApi extends HttpClient {
+  private static classInstance?: LicensesApi
+
+  public constructor() {
+    super('')
+  }
+
+  public static getInstance() {
+    if (!this.classInstance) {
+      this.classInstance = new LicensesApi()
+    }
+    return this.classInstance
+  }
+
+  public getItems = () => {
+    return this.instance.get<LicenseType>(`/third-party-licenses.json`, {
+      headers: {
+        Authorization: `Bearer ${UserService.getToken()}`,
+      },
+    })
+  }
+}

--- a/cx-portal/src/state/features/licenses/slice.ts
+++ b/cx-portal/src/state/features/licenses/slice.ts
@@ -32,6 +32,7 @@ const licensesSlice = createSlice({
   },
 })
 
-export const licensesSelector = (state: RootState): LicensesState => state.licenses
+export const licensesSelector = (state: RootState): LicensesState =>
+  state.licenses
 
 export default licensesSlice

--- a/cx-portal/src/state/features/licenses/slice.ts
+++ b/cx-portal/src/state/features/licenses/slice.ts
@@ -1,0 +1,37 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { RootState } from 'state/store'
+import { fetchItems } from './actions'
+import { LicensesState } from './types'
+
+const initialState: LicensesState = {
+  items: null,
+  loading: true,
+  error: '',
+}
+
+const licensesSlice = createSlice({
+  name: 'licenses',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchItems.pending, (state) => {
+      state.items = null
+      state.loading = true
+      state.error = ''
+    })
+    builder.addCase(fetchItems.fulfilled, (state, { payload }) => {
+      state.items = payload || []
+      state.loading = false
+      state.error = ''
+    })
+    builder.addCase(fetchItems.rejected, (state, action) => {
+      state.items = null
+      state.loading = false
+      state.error = action.error.message as string
+    })
+  },
+})
+
+export const licensesSelector = (state: RootState): LicensesState => state.licenses
+
+export default licensesSlice

--- a/cx-portal/src/state/features/licenses/types.ts
+++ b/cx-portal/src/state/features/licenses/types.ts
@@ -1,4 +1,4 @@
-import { Nullable, TableType } from "types/MainTypes"
+import { Nullable, TableType } from 'types/MainTypes'
 
 export type LicenseType = {
   type: string

--- a/cx-portal/src/state/features/licenses/types.ts
+++ b/cx-portal/src/state/features/licenses/types.ts
@@ -1,0 +1,12 @@
+import { Nullable, TableType } from "types/MainTypes"
+
+export type LicenseType = {
+  type: string
+  data: TableType
+}
+
+export type LicensesState = {
+  items: Nullable<LicenseType>
+  loading: boolean
+  error: string
+}

--- a/cx-portal/src/state/features/reducer.ts
+++ b/cx-portal/src/state/features/reducer.ts
@@ -5,12 +5,14 @@ import partnerNetworkSlice from 'state/features/partnerNetwork/partnerNetworkSli
 import userAdministrationSlice from 'state/features/userAdministration/userAdministrationSlice'
 import appMarketplaceSlice from 'state/features/appMarketplace/appMarketplaceSlice'
 import newsSlice from './news/slice'
+import licensesSlice from './licenses/slice'
 
 // Reducers need separate export for testing library
 export const reducers = {
   apps: appsSlice.reducer,
   user: userSlice,
   news: newsSlice.reducer,
+  licenses: licensesSlice.reducer,
   partnerNetwork: partnerNetworkSlice.reducer,
   appMarketplace: appMarketplaceSlice.reducer,
   userAdministration: userAdministrationSlice.reducer,

--- a/cx-portal/src/types/MainTypes.ts
+++ b/cx-portal/src/types/MainTypes.ts
@@ -1,3 +1,9 @@
+export type Nullable<T> = T | null
+
+export type TableType = {
+  head: string[]
+  body: string[][]
+}
 export interface GeographicCoordinate {
   longitude: number
   latitude: number

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "start:storybook": "cd cx-portal-shared-components && yarn start:storybook",
     "build:portal": "cd cx-portal && yarn build:portal",
     "start:portal": "cd cx-portal && yarn start",
-    "build:licenses": "find node_modules -name package.json -exec jq -r '.|\"\\(.name),\\(.version),\\(.license)\"' {} \\; | sort | uniq > cx-portal/public/third-party-licenses.txt",
+    "build:licenses:deprecated": "find node_modules -name package.json -exec jq -r '.|\"\\(.name),\\(.version),\\(.license)\"' {} \\; | sort | uniq > cx-portal/public/third-party-licenses.txt",
+    "build:licenses": "yarn licenses list --json --no-progress > cx-portal/public/third-party-licenses.json",
     "build:sources": "zip -r portal-frontend.zip cx-portal*/src package.json **/package.json yarn.lock -x '*.stories.*' -x '*.test.*' -x '*mock*' -x '*.ttf' -x '*.svg' -x '*.png'",
     "build:docker": "if [ -d \"./cx-portal/build\" ]; then yarn build:docker:prebuilt; else yarn build:docker:full; fi",
     "build:docker:full": "IMAGE=$npm_package_config_image && docker build -t $IMAGE -f .conf/Dockerfile.full --build-arg \"http_proxy=${http_proxy}\" --build-arg \"https_proxy=${https_proxy}\" --build-arg \"no_proxy=${no_proxy}\" .",
@@ -40,6 +41,9 @@
   },
   "devDependencies": {
     "husky": "^7.0.4",
+    "mkdirp": "^1.0.4",
+    "move-cli": "^2.0.0",
+    "rimraf": "^3.0.2",
     "yarn": "^1.22.18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,6 +3535,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
+"@types/minimist@^1.2.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/node-fetch@^2.5.7":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
@@ -4602,6 +4607,11 @@ array.prototype.map@^1.0.4:
     es-array-method-boxes-properly "^1.0.0"
     is-string "^1.0.7"
 
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
 arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
@@ -5359,7 +5369,16 @@ camelcase-css@2.0.1, camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-camelcase@^5.3.1:
+camelcase-keys@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
+  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
+  dependencies:
+    camelcase "^5.3.1"
+    map-obj "^4.0.0"
+    quick-lru "^4.0.1"
+
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -6334,6 +6353,19 @@ debug@^3.0.0, debug@^3.1.1, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+decamelize-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
+  integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.1.0, decamelize@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decimal.js@^10.2.1:
   version "10.3.1"
@@ -7963,6 +7995,17 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
@@ -8072,6 +8115,11 @@ handlebars@^4.7.7:
     wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
+
+hard-rejection@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
+  integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
 harmony-reflect@^1.4.6:
   version "1.6.2"
@@ -8925,6 +8973,11 @@ is-path-inside@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
 is-plain-obj@^2.0.0:
   version "2.1.0"
@@ -9829,7 +9882,7 @@ kind-of@^5.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -10104,6 +10157,16 @@ map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
+map-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+  integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
+
+map-obj@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
+  integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
+
 map-or-similar@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
@@ -10226,6 +10289,23 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+meow@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-6.1.1.tgz#1ad64c4b76b2a24dfb2f635fddcadf320d251467"
+  integrity sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==
+  dependencies:
+    "@types/minimist" "^1.2.0"
+    camelcase-keys "^6.2.2"
+    decamelize-keys "^1.1.0"
+    hard-rejection "^2.1.0"
+    minimist-options "^4.0.2"
+    normalize-package-data "^2.5.0"
+    read-pkg-up "^7.0.1"
+    redent "^3.0.0"
+    trim-newlines "^3.0.0"
+    type-fest "^0.13.1"
+    yargs-parser "^18.1.3"
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -10347,6 +10427,13 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -10354,12 +10441,14 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimist-options@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
+  integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
   dependencies:
-    brace-expansion "^1.1.7"
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
+    kind-of "^6.0.3"
 
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.6"
@@ -10438,6 +10527,14 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+move-cli@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/move-cli/-/move-cli-2.0.0.tgz#8228083707b9f3be4818821c2536efcc6cf63c93"
+  integrity sha512-/YUsTv5Gwemt9Iv2YkyVJvqphssA97I5fc2fr1Ak+Buh4pSDIPCTunx+wespnsEK3m31xVYwj8btzmdfUM90Dw==
+  dependencies:
+    meow "^6.0.0"
+    mv "^2.1.1"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -10483,6 +10580,15 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+mv@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
 nan@^2.12.1:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
@@ -10514,6 +10620,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -12093,6 +12204,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quick-lru@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
+  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
 quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
@@ -12855,6 +12971,13 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
+  dependencies:
+    glob "^6.0.1"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -14150,6 +14273,11 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+trim-newlines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
 trim-trailing-lines@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
@@ -14230,6 +14358,11 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
+  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
 type-fest@^0.16.0:
   version "0.16.0"
@@ -15321,6 +15454,14 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yargs-parser@^18.1.3:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.7:
   version "20.2.9"


### PR DESCRIPTION
this solves multiple issues:
- yarn scripts should now be platform independent and also work under Windows
- use the built in `yarn licenses list` instead of own slow script
- retrieve licenses via redux
- create an example case for redux data slic