### PR TITLE
CPLP-976: Change int to ng keycloak

### DIFF
--- a/cx-portal/src/services/EnvironmentService.ts
+++ b/cx-portal/src/services/EnvironmentService.ts
@@ -16,8 +16,14 @@ export const getAssetBase = () =>
   `${isLocal() ? LOCAL_SERVICES_FRONTEND : ''}/assets`
 
 //TODO: remove hard coded url and activate after setup of centralidp
-export const getCentralIdp = () =>
-  'https://catenaxdev003akssrv.germanywestcentral.cloudapp.azure.com/iamcentralidp/auth'
+export const getCentralIdp = () => {
+  const hostname = getHostname()
+  if (hostname === 'portal.int.demo.catena-x.net')
+    return 'https://centralidp.demo.catena-x.net/auth'
+  if (hostname === 'portal.catena-x.net')
+    return 'https://centralidp.catena-x.net/auth'
+  return 'https://catenaxdev003akssrv.germanywestcentral.cloudapp.azure.com/iamcentralidp/auth'
+}
 //export const getCentralIdp = () =>
 //  isLocal()
 //    ? LOCAL_SERVICES_CENTRALIDP

--- a/cx-portal/src/services/UserService.ts
+++ b/cx-portal/src/services/UserService.ts
@@ -8,7 +8,7 @@ import { error, info } from './LogService'
 const keycloakConfig: Keycloak.KeycloakConfig = {
   url: getCentralIdp(),
   realm: 'CX-Central',
-  clientId: 'catenax-portal',
+  clientId: 'Cl2-CX-Portal',
 }
 
 // TODO: add an ESLint exception until there is a solution


### PR DESCRIPTION
Change int to ng keycloak:
https://jira.catena-x.net/browse/CPLP-976
https://jira.catena-x.net/browse/CPLP-997
@oyo for now the change should only be activated on int, due to the client id change.