### PR TITLE
Change: Add new semantic url

### DIFF
--- a/cx-portal/src/features/digitalTwins/api.ts
+++ b/cx-portal/src/features/digitalTwins/api.ts
@@ -8,7 +8,7 @@ export class DigitalTwinApi extends HttpClient {
   private static classInstance?: DigitalTwinApi
 
   public constructor() {
-    super(`${getSemanticApiBase()}/twin-registry/registry/shell-descriptors`)
+    super(`${getSemanticApiBase()}registry/shell-descriptors`)
   }
 
   public static getInstance() {

--- a/cx-portal/src/services/EnvironmentService.ts
+++ b/cx-portal/src/services/EnvironmentService.ts
@@ -46,7 +46,7 @@ export const getBpdmApiBase = () =>
 //    : window.location.origin.replace('portal', 'bpdm')
 
 export const getSemanticApiBase = () =>
-  'https://catenaxintakssrv.germanywestcentral.cloudapp.azure.com/semantics'
+  'https://semantics.int.demo.catena-x.net/'
 
 const EnvironmentService = {
   isLocal,


### PR DESCRIPTION
The semantics team has new backend urls:

https://semantics.int.demo.catena-x.net/registry/
https://semantics.int.demo.catena-x.net/hub/

This PR adjusts the digital twin url.
