### PR TITLE
Change/Add semantic dev url

### DIFF
--- a/cx-portal/src/features/digitalTwins/api.ts
+++ b/cx-portal/src/features/digitalTwins/api.ts
@@ -8,7 +8,7 @@ export class Api extends HttpClient {
   private static classInstance?: Api
 
   public constructor() {
-    super(`${getSemanticApiBase()}registry/shell-descriptors`)
+    super(`${getSemanticApiBase()}registry/`)
   }
 
   public static getInstance() {
@@ -19,8 +19,11 @@ export class Api extends HttpClient {
   }
 
   public getTwins = (filters: FilterParams) =>
-    this.instance.get<TwinList>(`?${qs.stringify(filters)}`, getHeaders())
+    this.instance.get<TwinList>(
+      `shell-descriptors?${qs.stringify(filters)}`,
+      getHeaders()
+    )
 
   public getTwinById = (id: string) =>
-    this.instance.get<ShellDescriptor>(`/${id}`, getHeaders())
+    this.instance.get<ShellDescriptor>(`shell-descriptors/${id}`, getHeaders())
 }

--- a/cx-portal/src/services/EnvironmentService.ts
+++ b/cx-portal/src/services/EnvironmentService.ts
@@ -47,11 +47,8 @@ export const getBpdmApiBase = () =>
 
 export const getSemanticApiBase = () => {
   const hostname = getHostname()
-  if (hostname === 'portal.int.demo.catena-x.net') {
-    return 'https://semantics.int.demo.catena-x.net/'
-  } else {
-    return 'https://semantics.dev.demo.catena-x.net/'
-  }
+  if (hostname === 'portal.int.demo.catena-x.net') return 'https://semantics.int.demo.catena-x.net/'
+  return 'https://semantics.dev.demo.catena-x.net/'
 }
 
 const EnvironmentService = {

--- a/cx-portal/src/services/EnvironmentService.ts
+++ b/cx-portal/src/services/EnvironmentService.ts
@@ -45,8 +45,14 @@ export const getBpdmApiBase = () =>
 //    ? LOCAL_SERVICES_BPDM
 //    : window.location.origin.replace('portal', 'bpdm')
 
-export const getSemanticApiBase = () =>
-  'https://semantics.int.demo.catena-x.net/'
+export const getSemanticApiBase = () => {
+  const hostname = getHostname()
+  if(hostname === 'portal.int.demo.catena-x.net'){
+    return 'https://semantics.int.demo.catena-x.net/'
+  } else {
+    return 'https://semantics.dev.demo.catena-x.net/'
+  }
+}
 
 const EnvironmentService = {
   isLocal,

--- a/cx-portal/src/services/EnvironmentService.ts
+++ b/cx-portal/src/services/EnvironmentService.ts
@@ -47,7 +47,8 @@ export const getBpdmApiBase = () =>
 
 export const getSemanticApiBase = () => {
   const hostname = getHostname()
-  if (hostname === 'portal.int.demo.catena-x.net') return 'https://semantics.int.demo.catena-x.net/'
+  if (hostname === 'portal.int.demo.catena-x.net')
+    return 'https://semantics.int.demo.catena-x.net/'
   return 'https://semantics.dev.demo.catena-x.net/'
 }
 

--- a/cx-portal/src/services/EnvironmentService.ts
+++ b/cx-portal/src/services/EnvironmentService.ts
@@ -47,7 +47,7 @@ export const getBpdmApiBase = () =>
 
 export const getSemanticApiBase = () => {
   const hostname = getHostname()
-  if(hostname === 'portal.int.demo.catena-x.net'){
+  if (hostname === 'portal.int.demo.catena-x.net') {
     return 'https://semantics.int.demo.catena-x.net/'
   } else {
     return 'https://semantics.dev.demo.catena-x.net/'


### PR DESCRIPTION
- Adds the dev-url from the semantics team.
- Removes unnecessary slash in backend-url 
Important: At the moment the dev-backend of the semantic team uses the new dev idP: https://centralidp.dev.demo.catena-x.net/ in order to keep the config-adjustments low.