### PR TITLE
Minor Fixes for Semantic Hub and Registry

### DIFF
--- a/cx-portal/src/components/pages/DigitalTwins/TwinDetails.tsx
+++ b/cx-portal/src/components/pages/DigitalTwins/TwinDetails.tsx
@@ -46,10 +46,6 @@ export const TwinDetails = ({ twin }: { twin: ShellDescriptor }) => {
       {getDesciption(twin)}
       {hasSubmodels() && (
         <>
-          <Divider sx={{ mb: 2, mr: -2, ml: -2 }} />
-          <Typography sx={{ mb: 3, typography: 'label2' }}>
-            {t('content.digitaltwin.detail.assetId')}
-          </Typography>
           {twin.submodelDescriptors.length > 0 && (
             <DetailGrid
               topic={t('content.digitaltwin.detail.submodel_endpoints')}
@@ -57,13 +53,15 @@ export const TwinDetails = ({ twin }: { twin: ShellDescriptor }) => {
             />
           )}
           <Divider sx={{ mb: 2, mr: -2, ml: -2 }} />
+          <Typography sx={{ mb: 3, typography: 'label2' }}>
+            {t('content.digitaltwin.detail.assetId')}
+          </Typography>
           {twin.specificAssetIds.map((saId, index) => (
             <Box key={saId.key}>
               <DetailGrid
                 topic={t('content.digitaltwin.detail.key')}
                 content={saId.key}
               />
-              <Divider sx={{ mb: 2, mr: -2, ml: -2 }} />
               <DetailGrid
                 topic={t('content.digitaltwin.detail.value')}
                 content={saId.value}
@@ -125,17 +123,14 @@ export const TwinDetails = ({ twin }: { twin: ShellDescriptor }) => {
             topic={t('content.digitaltwin.detail.interface')}
             content={endpoint.interface}
           />
-          <Divider sx={{ mb: 2, mr: -2, ml: -2 }} />
           <DetailGrid
             topic={t('content.digitaltwin.detail.protocol')}
             content={endpoint.protocolInformation.endpointProtocol}
           />
-          <Divider sx={{ mb: 2, mr: -2, ml: -2 }} />
           <DetailGrid
             topic={t('content.digitaltwin.detail.protocol_endpoint')}
             content={endpoint.protocolInformation.endpointAddress}
           />
-          <Divider sx={{ mb: 2, mr: -2, ml: -2 }} />
           <DetailGrid
             topic={t('content.digitaltwin.detail.protocol_version')}
             content={endpoint.protocolInformation.endpointProtocolVersion}

--- a/cx-portal/src/components/pages/SemanticHub/ModelTable.tsx
+++ b/cx-portal/src/components/pages/SemanticHub/ModelTable.tsx
@@ -60,6 +60,10 @@ const ModelTable = ({ onModelSelect }: ModelTableProps) => {
           value: 'DRAFT',
           label: 'Draft',
         },
+        {
+          value: 'DEPRECATED',
+          label: 'Deprecated',
+        },
       ],
     },
   ]


### PR DESCRIPTION
1. Adds Depricated Status to SE Hub Filter: https://jira.catena-x.net/browse/A1SLDT-673
2. Removes Divider between Key-Value Props 
3. Removes Divider between Twin endpoint-values
4. Changes order of items in twin detail