### PR TITLE
fixed copy-to-clipboard and breadcrumb nav

### DIFF
--- a/cx-portal/src/components/shared/basic/KeyValueView/index.tsx
+++ b/cx-portal/src/components/shared/basic/KeyValueView/index.tsx
@@ -30,9 +30,9 @@ export const KeyValueView = ({ cols, title, items }: KeyValueViewProps) => {
         sx={{
           cursor: 'pointer',
           display: 'flex',
-          color: copied === item.key ? '#00cc00' : '#eeeeee',
+          color: copied === item.value ? '#00cc00' : '#eeeeee',
           ':hover': {
-            color: copied === item.key ? '#00cc00' : '#cccccc',
+            color: copied === item.value ? '#00cc00' : '#cccccc',
           },
         }}
         onClick={async () => {
@@ -74,9 +74,9 @@ export const KeyValueView = ({ cols, title, items }: KeyValueViewProps) => {
       </Box>
       <Box>
         {Array.isArray(items) ? (
-          items.map((item) => (
+          items.map((item, i) => (
             <Box
-              key={item.key}
+              key={i}
               sx={{
                 display: 'flex',
                 justifyContent: 'space-between',
@@ -93,6 +93,7 @@ export const KeyValueView = ({ cols, title, items }: KeyValueViewProps) => {
           ))
         ) : (
           <Box
+            key={items.value.toString()}
             sx={{
               padding: '18px 24px',
               borderBottom: '1px solid #EDF0F4',

--- a/cx-portal/src/components/shared/frame/PageHeaderWithCrumbs/index.tsx
+++ b/cx-portal/src/components/shared/frame/PageHeaderWithCrumbs/index.tsx
@@ -30,6 +30,7 @@ export default function PageHeaderWithCrumbs({ crumbs }: { crumbs: string[] }) {
           ))
           .concat(
             <NavLink
+              key={page}
               style={{
                 display: 'block',
                 marginBottom: '2px',
@@ -42,7 +43,7 @@ export default function PageHeaderWithCrumbs({ crumbs }: { crumbs: string[] }) {
               {title}
             </NavLink>
           )}
-        onBackButtonClick={() => navigate(-1)}
+        onBackButtonClick={() => navigate(`/${path[path.length - 1]}`)}
       />
     </PageHeader>
   )


### PR DESCRIPTION
small fixes:
- copy-to-clipboard now works
- breadcrumb navigation now leads to the last bread crumb and not just browser history back
- fixes some missing react keys