### PR TITLE
Feature/cplp 1720/subscription app&service-endpoint-cleanup

### DIFF
--- a/cx-portal/src/features/apps/apiSlice.ts
+++ b/cx-portal/src/features/apps/apiSlice.ts
@@ -147,7 +147,7 @@ export const apiSlice = createApi({
     }),
     addSubscribeApp: builder.mutation<void, SubscriptionAppRequest>({
       query: (data: SubscriptionAppRequest) => ({
-        url: `/api/apps/${data.appId}/subscribe-consent`,
+        url: `/api/apps/${data.appId}/subscribe`,
         method: 'POST',
         body: data.body,
       }),

--- a/cx-portal/src/features/serviceMarketplace/serviceApiSlice.ts
+++ b/cx-portal/src/features/serviceMarketplace/serviceApiSlice.ts
@@ -87,7 +87,7 @@ export const apiSlice = createApi({
     }),
     addSubscribeService: builder.mutation<void, SubscriptionServiceRequest>({
       query: (data: SubscriptionServiceRequest) => ({
-        url: `/api/services/${data.serviceId}/subscribe-consent`,
+        url: `/api/services/${data.serviceId}/subscribe`,
         method: 'POST',
         body: data.body,
       }),


### PR DESCRIPTION
Hi Nidhi, we have named the endpoint again /subscribe
Logic is as you implemented it :) so only the "-consent" got deleted again.
I did the fix quickly